### PR TITLE
Bump Mermaid to support activation boxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom-space-pen-views": "^2.0.5",
     "d3": "~3.5.6",
     "fs-plus": "^2.8.1",
-    "mermaid": "~0.5.8",
+    "mermaid": "~6.0",
     "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
Activation boxes is supported from 6.0.0.
https://github.com/knsv/mermaid/releases/tag/6.0.0
The current version claims that's an invalid syntax. So could you update Mermaid?
Thanks.
