### PR TITLE
Couldn't find the package with `mermaid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Preview diagrams and flowcharts by mermaid library.
 
 ## Installation
 
-In Atom, open [Preferences > Packages], search for `mermaid` package. Once it found, click `Install` button to install package.
+In Atom, open [Preferences > Packages], and search the package with `atom-mermaid`. Once it found, click `Install` button to install the package.
 
 ### Manual installation
 


### PR DESCRIPTION
I don't know if Atom changed the behavior but it looks that `mermaid` doesn't match the package. 
With `atom-mermaid`, I could find it on the top.
