### PR TITLE
Fix error messages not displaying

### DIFF
--- a/lib/mermaid-view.coffee
+++ b/lib/mermaid-view.coffee
@@ -118,9 +118,9 @@ module.exports =
       div.innerHTML = mmdText
       @html $ div
       try
-        mermaid.parseError = (error, hash)->
-          div.innerHTML = error.replace("\n", "<br>")
         mermaid.init({ "theme": "default" }, div)
+      catch error
+        div.innerHTML = error.message.replace("\n", "<br>")
 
     getTitle: ->
       if @editor?


### PR DESCRIPTION
Shows any error messages thrown by mermaid in the preview window.

Without this fix, if there are any errors, I would just see a blank preview pane.